### PR TITLE
Resolved bento warning

### DIFF
--- a/adjust
+++ b/adjust
@@ -76,7 +76,7 @@ def read_desc():
 
     try:
         f = open(DESC_FILE)
-        d = yaml.load(f)
+        d = yaml.safe_load(f)
     except IOError as e:
         raise ConfigError("cannot read configuration from {}:{}".format(DESC_FILE,e.strerror))
     except yaml.error.YAMLError as e:


### PR DESCRIPTION
Bento Output:

```
bandit yaml-load https://bandit.readthedocs.io/en/latest/plugins/b506_yaml_load.html  
     > adjust:79                                                                      
     ╷                                                                                
   79│   d = yaml.load(f)                                                             
     ╵                                                                                
     = Use of unsafe yaml load. Allows instantiation of arbitrary objects.
       Consider yaml.safe_load().
```